### PR TITLE
Use libcgo.h instead of generating C code from within Go

### DIFF
--- a/1.18_linux/runtime/cgo/gcc_libinit.c.patch
+++ b/1.18_linux/runtime/cgo/gcc_libinit.c.patch
@@ -26,3 +26,4 @@
 			CPU_FREE(cpu_set);
 #endif
 			return 0;
+		}

--- a/1.18_linux/runtime/cgo/gcc_libinit.c.patch
+++ b/1.18_linux/runtime/cgo/gcc_libinit.c.patch
@@ -5,3 +5,24 @@
   #define _GNU_SOURCE
 #endif
 #include <pthread.h>
+//--from
+		err = pthread_create(thread, attr, pfn, arg);
+		if (err == 0) {
+			pthread_detach(*thread);
+			return 0;
+		}
+//--to
+		err = pthread_create(thread, attr, pfn, arg);
+		if (err == 0) {
+			pthread_detach(*thread);
+#if __aarch64__
+			cpu_set_t *cpu_set = CPU_ALLOC(HITSUMABUSHI_NUMCPU);
+			size_t size = CPU_ALLOC_SIZE(HITSUMABUSHI_NUMCPU);
+			CPU_ZERO_S(size, cpu_set);
+			for (int i = 0; i < HITSUMABUSHI_NUMCPU; i++) {
+				CPU_SET_S(i, size, cpu_set);
+			}
+			pthread_setaffinity_np(*thread, size, cpu_set);
+			CPU_FREE(cpu_set);
+#endif
+			return 0;

--- a/1.18_linux/runtime/cgo/gcc_linux_arm64.c.patch
+++ b/1.18_linux/runtime/cgo/gcc_linux_arm64.c.patch
@@ -469,6 +469,15 @@ int32_t c_osyield() {
   return sched_yield();
 }
 
+int32_t c_sched_getaffinity(pid_t pid, size_t cpusetsize, void *mask) {
+    for (int32_t i = 0; i < HITSUMABUSHI_NUMCPU; i += 8)
+        ((unsigned char*)mask)[i / 8] = (unsigned char)((1u << (HITSUMABUSHI_NUMCPU - i)) - 1);
+    // https://man7.org/linux/man-pages/man2/sched_setaffinity.2.html
+    // > On success, the raw sched_getaffinity() system call returns the
+    // > number of bytes placed copied into the mask buffer;
+    return (HITSUMABUSHI_NUMCPU + 7) / 8;
+}
+
 int32_t c_read(int32_t fd, void *p, int32_t n) {
   if (fd >= kFDOffset) {
     return read_pseudo_file(fd, p, n);

--- a/1.19_linux/runtime/cgo/gcc_libinit.c.patch
+++ b/1.19_linux/runtime/cgo/gcc_libinit.c.patch
@@ -5,3 +5,25 @@
   #define _GNU_SOURCE
 #endif
 #include <pthread.h>
+//--from
+		err = pthread_create(thread, attr, pfn, arg);
+		if (err == 0) {
+			pthread_detach(*thread);
+			return 0;
+		}
+//--to
+		err = pthread_create(thread, attr, pfn, arg);
+		if (err == 0) {
+			pthread_detach(*thread);
+#if __aarch64__
+			cpu_set_t *cpu_set = CPU_ALLOC(HITSUMABUSHI_NUMCPU);
+			size_t size = CPU_ALLOC_SIZE(HITSUMABUSHI_NUMCPU);
+			CPU_ZERO_S(size, cpu_set);
+			for (int i = 0; i < HITSUMABUSHI_NUMCPU; i++) {
+				CPU_SET_S(i, size, cpu_set);
+			}
+			pthread_setaffinity_np(*thread, size, cpu_set);
+			CPU_FREE(cpu_set);
+#endif
+			return 0;
+		}

--- a/1.19_linux/runtime/cgo/gcc_linux_arm64.c.patch
+++ b/1.19_linux/runtime/cgo/gcc_linux_arm64.c.patch
@@ -351,6 +351,15 @@ int32_t c_osyield() {
   return sched_yield();
 }
 
+int32_t c_sched_getaffinity(pid_t pid, size_t cpusetsize, void *mask) {
+    for (int32_t i = 0; i < HITSUMABUSHI_NUMCPU; i += 8)
+        ((unsigned char*)mask)[i / 8] = (unsigned char)((1u << (HITSUMABUSHI_NUMCPU - i)) - 1);
+    // https://man7.org/linux/man-pages/man2/sched_setaffinity.2.html
+    // > On success, the raw sched_getaffinity() system call returns the
+    // > number of bytes placed copied into the mask buffer;
+    return (HITSUMABUSHI_NUMCPU + 7) / 8;
+}
+
 int32_t c_read(int32_t fd, void *p, int32_t n) {
   if (fd >= kFDOffset) {
     return read_pseudo_file(fd, p, n);

--- a/overlay.go
+++ b/overlay.go
@@ -256,41 +256,6 @@ func GenOverlayJSON(options ...Option) ([]byte, error) {
 			return fmt.Errorf("hitsumabushi: unexpected modType: %s", modType)
 		}
 
-		switch {
-		case cfg.os == "linux" && pkg == "runtime/cgo" && origFilename == "gcc_linux_arm64.c":
-			// The number of CPU is defined at runtime/cgo/gcc_linux_arm64.c
-			numBytes := (cfg.numCPU-1)/8 + 1
-			tmpl := `
-int32_t c_sched_getaffinity(pid_t pid, size_t cpusetsize, void *mask) {
-{{.Masking}}
-  // https://man7.org/linux/man-pages/man2/sched_setaffinity.2.html
-  // > On success, the raw sched_getaffinity() system call returns the
-  // > number of bytes placed copied into the mask buffer;
-  return {{.NumBytes}};
-}
-`
-			n := cfg.numCPU
-			var masking string
-			for i := 0; i < numBytes; i++ {
-				mask := 0
-				m := 8
-				if n < m {
-					m = n
-				}
-				for j := 0; j < m; j++ {
-					mask |= 1 << j
-				}
-				masking += fmt.Sprintf("  ((char*)mask)[%d] = 0x%x;\n", i, mask)
-				n -= 8
-			}
-
-			tmpl = strings.ReplaceAll(tmpl, "{{.Masking}}", masking)
-			tmpl = strings.ReplaceAll(tmpl, "{{.NumBytes}}", fmt.Sprintf("%d", numBytes))
-			if _, err := dst.Write([]byte(tmpl)); err != nil {
-				return err
-			}
-		}
-
 		return nil
 	}); err != nil {
 		return nil, err
@@ -298,36 +263,13 @@ int32_t c_sched_getaffinity(pid_t pid, size_t cpusetsize, void *mask) {
 
 	switch cfg.os {
 	case "linux":
-		// Add pthread_setaffinity_np.
-		{
-			indent := "\t\t\t"
-			setCPU := []string{
-				indent + fmt.Sprintf(`cpu_set_t *cpu_set = CPU_ALLOC(%d);`, cfg.numCPU),
-				indent + fmt.Sprintf(`size_t size = CPU_ALLOC_SIZE(%d);`, cfg.numCPU),
-				indent + `CPU_ZERO_S(size, cpu_set);`,
-				indent + fmt.Sprintf(`for (int i = 0; i < %d; i++) {`, cfg.numCPU),
-				indent + `	CPU_SET_S(i, size, cpu_set);`,
-				indent + `}`,
-				indent + `pthread_setaffinity_np(*thread, size, cpu_set);`,
-				indent + `CPU_FREE(cpu_set);`,
-			}
+		// Add defines
+		defines := []string{
+			"#define HITSUMABUSHI_NUMCPU " + fmt.Sprintf("%d", cfg.numCPU),
+		}
 
-			old := `		err = pthread_create(thread, attr, pfn, arg);
-		if (err == 0) {
-			pthread_detach(*thread);
-			return 0;
-		}`
-
-			new := strings.Replace(`		err = pthread_create(thread, attr, pfn, arg);
-		if (err == 0) {
-			pthread_detach(*thread);
-{{.SetCPU}}
-			return 0;
-		}`, "{{.SetCPU}}", strings.Join(setCPU, "\n"), 1)
-
-			if err := replace(tmpDir, replaces, "runtime/cgo", "gcc_libinit.c", old, new, cfg.os); err != nil {
-				return nil, err
-			}
+		if err := replace(tmpDir, replaces, "runtime/cgo", "libcgo.h", "", strings.Join(defines, "\n"), cfg.os); err != nil {
+			return nil, err
 		}
 
 		// Replace the arguments.


### PR DESCRIPTION
Hi! This small change helps reducing the amount of code that is generated on the Go side. This will make it easier to port Hitsumabushi to other target platforms. Please let me know what you think.