### PR TITLE
Rework affinity functions

### DIFF
--- a/1.18_linux/runtime/cgo/gcc_libinit.c.patch
+++ b/1.18_linux/runtime/cgo/gcc_libinit.c.patch
@@ -5,3 +5,25 @@
   #define _GNU_SOURCE
 #endif
 #include <pthread.h>
+//--from
+		err = pthread_create(thread, attr, pfn, arg);
+		if (err == 0) {
+			pthread_detach(*thread);
+			return 0;
+		}
+//--to
+		err = pthread_create(thread, attr, pfn, arg);
+		if (err == 0) {
+			pthread_detach(*thread);
+#ifdef __USE_GNU // pthread_setaffinity_np() is a glibc extension
+			cpu_set_t *cpu_set = CPU_ALLOC({{.NumCPU}});
+			size_t size = CPU_ALLOC_SIZE({{.NumCPU}});
+			CPU_ZERO_S(size, cpu_set);
+			for (int i = 0; i < {{.NumCPU}}; i++) {
+				CPU_SET_S(i, size, cpu_set);
+			}
+			pthread_setaffinity_np(*thread, size, cpu_set);
+			CPU_FREE(cpu_set);
+#endif
+			return 0;
+		}

--- a/1.18_linux/runtime/cgo/gcc_libinit.c.patch
+++ b/1.18_linux/runtime/cgo/gcc_libinit.c.patch
@@ -16,10 +16,12 @@
 		if (err == 0) {
 			pthread_detach(*thread);
 #ifdef __USE_GNU // pthread_setaffinity_np() is a glibc extension
-			cpu_set_t *cpu_set = CPU_ALLOC({{.NumCPU}});
-			size_t size = CPU_ALLOC_SIZE({{.NumCPU}});
+			extern int32_t hitsumabushi_getproccount();
+			int32_t numcpu = hitsumabushi_getproccount();
+			cpu_set_t *cpu_set = CPU_ALLOC(numcpu);
+			size_t size = CPU_ALLOC_SIZE(numcpu);
 			CPU_ZERO_S(size, cpu_set);
-			for (int i = 0; i < {{.NumCPU}}; i++) {
+			for (int i = 0; i < numcpu; i++) {
 				CPU_SET_S(i, size, cpu_set);
 			}
 			pthread_setaffinity_np(*thread, size, cpu_set);

--- a/1.18_linux/runtime/cgo/gcc_linux_arm64.c.patch
+++ b/1.18_linux/runtime/cgo/gcc_linux_arm64.c.patch
@@ -469,13 +469,16 @@ int32_t c_osyield() {
   return sched_yield();
 }
 
+extern int32_t hitsumabushi_getproccount();
+
 int32_t c_sched_getaffinity(pid_t pid, size_t cpusetsize, void *mask) {
-    for (int32_t i = 0; i < {{.NumCPU}}; i += 8)
-        ((unsigned char*)mask)[i / 8] = (unsigned char)((1u << ({{.NumCPU}} - i)) - 1);
+    int32_t numcpu = hitsumabushi_getproccount();
+    for (int32_t i = 0; i < numcpu; i += 8)
+        ((unsigned char*)mask)[i / 8] = (unsigned char)((1u << (numcpu - i)) - 1);
     // https://man7.org/linux/man-pages/man2/sched_setaffinity.2.html
     // > On success, the raw sched_getaffinity() system call returns the
     // > number of bytes placed copied into the mask buffer;
-    return ({{.NumCPU}} + 7) / 8;
+    return (numcpu + 7) / 8;
 }
 
 int32_t c_read(int32_t fd, void *p, int32_t n) {

--- a/1.18_linux/runtime/cgo/gcc_linux_arm64.c.patch
+++ b/1.18_linux/runtime/cgo/gcc_linux_arm64.c.patch
@@ -469,6 +469,15 @@ int32_t c_osyield() {
   return sched_yield();
 }
 
+int32_t c_sched_getaffinity(pid_t pid, size_t cpusetsize, void *mask) {
+    for (int32_t i = 0; i < {{.NumCPU}}; i += 8)
+        ((unsigned char*)mask)[i / 8] = (unsigned char)((1u << ({{.NumCPU}} - i)) - 1);
+    // https://man7.org/linux/man-pages/man2/sched_setaffinity.2.html
+    // > On success, the raw sched_getaffinity() system call returns the
+    // > number of bytes placed copied into the mask buffer;
+    return ({{.NumCPU}} + 7) / 8;
+}
+
 int32_t c_read(int32_t fd, void *p, int32_t n) {
   if (fd >= kFDOffset) {
     return read_pseudo_file(fd, p, n);

--- a/1.18_linux/runtime/cgo/hitsumabushi_cpu_linux.c
+++ b/1.18_linux/runtime/cgo/hitsumabushi_cpu_linux.c
@@ -1,0 +1,5 @@
+#include <stdint.h>
+
+int32_t hitsumabushi_getproccount() {
+	return {{.NumCPU}};
+}

--- a/1.19_linux/runtime/cgo/gcc_libinit.c.patch
+++ b/1.19_linux/runtime/cgo/gcc_libinit.c.patch
@@ -5,3 +5,25 @@
   #define _GNU_SOURCE
 #endif
 #include <pthread.h>
+//--from
+		err = pthread_create(thread, attr, pfn, arg);
+		if (err == 0) {
+			pthread_detach(*thread);
+			return 0;
+		}
+//--to
+		err = pthread_create(thread, attr, pfn, arg);
+		if (err == 0) {
+			pthread_detach(*thread);
+#ifdef __USE_GNU // pthread_setaffinity_np() is a glibc extension
+			cpu_set_t *cpu_set = CPU_ALLOC({{.NumCPU}});
+			size_t size = CPU_ALLOC_SIZE({{.NumCPU}});
+			CPU_ZERO_S(size, cpu_set);
+			for (int i = 0; i < {{.NumCPU}}; i++) {
+				CPU_SET_S(i, size, cpu_set);
+			}
+			pthread_setaffinity_np(*thread, size, cpu_set);
+			CPU_FREE(cpu_set);
+#endif
+			return 0;
+		}

--- a/1.19_linux/runtime/cgo/gcc_libinit.c.patch
+++ b/1.19_linux/runtime/cgo/gcc_libinit.c.patch
@@ -16,10 +16,12 @@
 		if (err == 0) {
 			pthread_detach(*thread);
 #ifdef __USE_GNU // pthread_setaffinity_np() is a glibc extension
-			cpu_set_t *cpu_set = CPU_ALLOC({{.NumCPU}});
-			size_t size = CPU_ALLOC_SIZE({{.NumCPU}});
+			extern int32_t hitsumabushi_getproccount();
+			int32_t numcpu = hitsumabushi_getproccount();
+			cpu_set_t *cpu_set = CPU_ALLOC(numcpu);
+			size_t size = CPU_ALLOC_SIZE(numcpu);
 			CPU_ZERO_S(size, cpu_set);
-			for (int i = 0; i < {{.NumCPU}}; i++) {
+			for (int i = 0; i < numcpu; i++) {
 				CPU_SET_S(i, size, cpu_set);
 			}
 			pthread_setaffinity_np(*thread, size, cpu_set);

--- a/1.19_linux/runtime/cgo/gcc_linux_arm64.c.patch
+++ b/1.19_linux/runtime/cgo/gcc_linux_arm64.c.patch
@@ -351,13 +351,16 @@ int32_t c_osyield() {
   return sched_yield();
 }
 
+extern int32_t hitsumabushi_getproccount();
+
 int32_t c_sched_getaffinity(pid_t pid, size_t cpusetsize, void *mask) {
-    for (int32_t i = 0; i < {{.NumCPU}}; i += 8)
-        ((unsigned char*)mask)[i / 8] = (unsigned char)((1u << ({{.NumCPU}} - i)) - 1);
+    int32_t numcpu = hitsumabushi_getproccount();
+    for (int32_t i = 0; i < numcpu; i += 8)
+        ((unsigned char*)mask)[i / 8] = (unsigned char)((1u << (numcpu - i)) - 1);
     // https://man7.org/linux/man-pages/man2/sched_setaffinity.2.html
     // > On success, the raw sched_getaffinity() system call returns the
     // > number of bytes placed copied into the mask buffer;
-    return ({{.NumCPU}} + 7) / 8;
+    return (numcpu + 7) / 8;
 }
 
 int32_t c_read(int32_t fd, void *p, int32_t n) {

--- a/1.19_linux/runtime/cgo/gcc_linux_arm64.c.patch
+++ b/1.19_linux/runtime/cgo/gcc_linux_arm64.c.patch
@@ -351,6 +351,15 @@ int32_t c_osyield() {
   return sched_yield();
 }
 
+int32_t c_sched_getaffinity(pid_t pid, size_t cpusetsize, void *mask) {
+    for (int32_t i = 0; i < {{.NumCPU}}; i += 8)
+        ((unsigned char*)mask)[i / 8] = (unsigned char)((1u << ({{.NumCPU}} - i)) - 1);
+    // https://man7.org/linux/man-pages/man2/sched_setaffinity.2.html
+    // > On success, the raw sched_getaffinity() system call returns the
+    // > number of bytes placed copied into the mask buffer;
+    return ({{.NumCPU}} + 7) / 8;
+}
+
 int32_t c_read(int32_t fd, void *p, int32_t n) {
   if (fd >= kFDOffset) {
     return read_pseudo_file(fd, p, n);

--- a/1.19_linux/runtime/cgo/hitsumabushi_cpu_linux.c
+++ b/1.19_linux/runtime/cgo/hitsumabushi_cpu_linux.c
@@ -1,0 +1,5 @@
+#include <stdint.h>
+
+int32_t hitsumabushi_getproccount() {
+	return {{.NumCPU}};
+}

--- a/overlay.go
+++ b/overlay.go
@@ -276,10 +276,8 @@ func GenOverlayJSON(options ...Option) ([]byte, error) {
 	switch cfg.os {
 	case "linux":
 		// Replace {{.NumCPU}} with the configured number of CPUs
-		for _, file := range []string{"gcc_linux_arm64.c", "gcc_libinit.c"} {
-			if err := replace(tmpDir, replaces, "runtime/cgo", file, "{{.NumCPU}}", fmt.Sprintf("%d", cfg.numCPU), cfg.os); err != nil {
-				return nil, err
-			}
+		if err := replace(tmpDir, replaces, "runtime/cgo", "hitsumabushi_cpu_linux.c", "{{.NumCPU}}", fmt.Sprintf("%d", cfg.numCPU), cfg.os); err != nil {
+			return nil, err
 		}
 
 		// Replace the arguments.

--- a/overlay.go
+++ b/overlay.go
@@ -652,3 +652,13 @@ func FutexFilePath(os string) (string, error) {
 func MemoryFilePath(os string) (string, error) {
 	return replacementFilePath("MemoryFilePath", "runtime/cgo", os, "hitsumabushi_mem_linux.c")
 }
+
+// CPUFilePath returns a C file's path for the CPU functions.
+// The file includes this function:
+//
+//   - int32_t hitsumabushi_getproccount()
+//
+// The default implementation uses the hardcoded cfg.NumCPU
+func CPUFilePath(os string) (string, error) {
+	return replacementFilePath("CPUFilePath", "runtime/cgo", os, "hitsumabushi_cpu_linux.c")
+}

--- a/overlay.go
+++ b/overlay.go
@@ -658,7 +658,7 @@ func MemoryFilePath(os string) (string, error) {
 //
 //   - int32_t hitsumabushi_getproccount()
 //
-// The default implementation uses the hardcoded cfg.NumCPU
+// The default implementation uses the NumCPU option value.
 func CPUFilePath(os string) (string, error) {
 	return replacementFilePath("CPUFilePath", "runtime/cgo", os, "hitsumabushi_cpu_linux.c")
 }


### PR DESCRIPTION
Hello! This is a reworked version of #7 with I believe all your comments addressed.
 - new `hitsumabushi_getproccount()` function
 - can be overridden using `hitsumabushi.CPUFilePath()`
 - protect `pthread_setaffinity_np()` with `#ifdef __USE_GNU` instead of `#if __aarch64__` to make sure we’re on glibc
 - the arguments to the `replace()` call are no longer confusing