### PR TITLE
stubs2.go: compatibility fix for previous versions of Go 1.19 and Go 1.18

### DIFF
--- a/1.18_linux/runtime/stubs2.go.patch
+++ b/1.18_linux/runtime/stubs2.go.patch
@@ -1,14 +1,8 @@
 //--from
-import (
-	"runtime/internal/atomic"
-	"unsafe"
-)
+package runtime
 //--to
-import (
-	"internal/abi"
-	"runtime/internal/atomic"
-	"unsafe"
-)
+package runtime
+import "internal/abi"
 //--from
 func read(fd int32, p unsafe.Pointer, n int32) int32
 //--to

--- a/1.19_linux/runtime/stubs2.go.patch
+++ b/1.19_linux/runtime/stubs2.go.patch
@@ -1,14 +1,8 @@
 //--from
-import (
-	"runtime/internal/atomic"
-	"unsafe"
-)
+package runtime
 //--to
-import (
-	"internal/abi"
-	"runtime/internal/atomic"
-	"unsafe"
-)
+package runtime
+import "internal/abi"
 //--from
 func read(fd int32, p unsafe.Pointer, n int32) int32
 //--to


### PR DESCRIPTION
There is no Go 1.19.3 package for the Debian distribution yet, so I can no longer use recent versions of Histumabushi.

I’m suggesting this change to make the patch work on 1.19.2 too. I admit the patch chunk is now less robust and maybe less clear, but it works… let me know if I can do it another way.