### PR TITLE
Rework filesystem syscalls

### DIFF
--- a/1.19_linux/internal/reflectlite/reflect_mirror_test.go.patch
+++ b/1.19_linux/internal/reflectlite/reflect_mirror_test.go.patch
@@ -1,0 +1,6 @@
+//--from
+func TestMirrorWithReflect(t *testing.T) {
+//--to
+func TestMirrorWithReflect(t *testing.T) {
+       t.Skip("file is not supported in this environment")
+       return

--- a/1.19_linux/runtime/cgo/hitsumabushi_filesystem_linux.c
+++ b/1.19_linux/runtime/cgo/hitsumabushi_filesystem_linux.c
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2022 The Hitsumabushi Authors
+
+// This file defines C functions and system calls for Cgo.
+
+#include <pthread.h>
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdatomic.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+
+#include "libcgo.h"
+#include "libcgo_unix.h"
+
+static const int kFDOffset = 100;
+
+typedef struct {
+  const void* content;
+  size_t      content_size;
+  size_t      current;
+  int32_t     fd;
+} pseudo_file;
+
+// TODO: Do we need to protect this by mutex?
+static pseudo_file pseudo_files[100];
+
+static pthread_mutex_t* pseudo_file_mutex() {
+  static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+  return &mutex;
+}
+
+static int32_t open_pseudo_file(const void* content, size_t content_size) {
+  pthread_mutex_lock(pseudo_file_mutex());
+
+  int index = 0;
+  int found = 0;
+  for (int i = 0; i < sizeof(pseudo_files) / sizeof(pseudo_file); i++) {
+    if (pseudo_files[i].fd == 0) {
+      index = i;
+      found = 1;
+      break;
+    }
+  }
+  if (!found) {
+    // Too many pseudo files are opened.
+    pthread_mutex_unlock(pseudo_file_mutex());
+    return -1;
+  }
+  int32_t fd = index + kFDOffset;
+  pseudo_files[index].content = content;
+  pseudo_files[index].content_size = content_size;
+  pseudo_files[index].current = 0;
+  pseudo_files[index].fd = fd;
+
+  pthread_mutex_unlock(pseudo_file_mutex());
+  return fd;
+}
+
+static size_t read_pseudo_file(int32_t fd, void *p, int32_t n) {
+  pthread_mutex_lock(pseudo_file_mutex());
+
+  int32_t index = fd - kFDOffset;
+  pseudo_file *file = &pseudo_files[index];
+  size_t rest = file->content_size - file->current;
+  if (rest < n) {
+    n = rest;
+  }
+  memcpy(p, file->content + file->current, n);
+  pseudo_files[index].current += n;
+
+  pthread_mutex_unlock(pseudo_file_mutex());
+  return n;
+}
+
+static void close_pseudo_file(int32_t fd) {
+  pthread_mutex_lock(pseudo_file_mutex());
+
+  int32_t index = fd - kFDOffset;
+  pseudo_files[index].content = NULL;
+  pseudo_files[index].content_size = 0;
+  pseudo_files[index].current = 0;
+  pseudo_files[index].fd = 0;
+
+  pthread_mutex_unlock(pseudo_file_mutex());
+}
+
+int32_t hitsumabushi_closefd(int32_t fd) {
+  if (fd >= kFDOffset) {
+    close_pseudo_file(fd);
+    return 0;
+  }
+  fprintf(stderr, "syscall close(%d) is not implemented\n", fd);
+  return 0;
+}
+
+int32_t hitsumabushi_open(char *name, int32_t mode, int32_t perm) {
+  if (strcmp(name, "/proc/self/auxv") == 0) {
+    static const char auxv[] =
+      "\x06\x00\x00\x00\x00\x00\x00\x00"  // _AT_PAGESZ tag (6)
+      "\x00\x10\x00\x00\x00\x00\x00\x00"  // 4096 bytes per page
+      "\x00\x00\x00\x00\x00\x00\x00\x00"  // Dummy bytes
+      "\x00\x00\x00\x00\x00\x00\x00\x00"; // Dummy bytes
+    return open_pseudo_file(auxv, sizeof(auxv) / sizeof(char));
+  }
+  if (strcmp(name, "/sys/kernel/mm/transparent_hugepage/hpage_pmd_size") == 0) {
+    static const char hpage_pmd_size[] =
+      "\x30\x5c"; // '0', '\n'
+    return open_pseudo_file(hpage_pmd_size, sizeof(hpage_pmd_size) / sizeof(char));
+  }
+  fprintf(stderr, "syscall open(%s, %d, %d) is not implemented\n", name, mode, perm);
+  const static int kENOENT = 0x2;
+  return kENOENT;
+}
+
+int32_t hitsumabushi_read(int32_t fd, void *p, int32_t n) {
+  if (fd >= kFDOffset) {
+    return read_pseudo_file(fd, p, n);
+  }
+  fprintf(stderr, "syscall read(%d, %p, %d) is not implemented\n", fd, p, n);
+  const static int kEBADF = 0x9;
+  return kEBADF;
+}
+
+int32_t hitsumabushi_write1(uintptr_t fd, void *p, int32_t n) {
+  static pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
+  int32_t ret = 0;
+  pthread_mutex_lock(&m);
+  switch (fd) {
+  case 1:
+    ret = fwrite(p, 1, n, stdout);
+    fflush(stdout);
+    break;
+  case 2:
+    ret = fwrite(p, 1, n, stderr);
+    fflush(stderr);
+    break;
+  default:
+    fprintf(stderr, "syscall write(%lu, %p, %d) is not implemented\n", fd, p, n);
+    ret = -EBADF;
+    break;
+  }
+  pthread_mutex_unlock(&m);
+  return ret;
+}
+
+int32_t hitsumabushi_lseek(uintptr_t fd, off_t offset, int32_t whence) {
+  fprintf(stderr, "syscall lseek(%lu, %lu, %d) is not implemented\n", fd, offset, whence);
+  return -ENOSYS;
+}
+
+int32_t hitsumabushi_fcntl(int32_t fd, int32_t cmd, int32_t arg)
+{
+  if (fd == 0 || fd == 1 || fd == 2) {
+    if (cmd == F_GETFL) {
+      return 0;
+    }
+  }
+  fprintf(stderr, "syscall fcntl(%d, %d, %d) is not implemented\n", fd, cmd, arg);
+  return -EBADF;
+}
+
+int32_t hitsumabushi_fstat(int32_t fd, struct stat *stat)
+{
+  fprintf(stderr, "syscall fstat(%d, %p) is not implemented\n", fd, stat);
+  return -ENOSYS;
+}
+
+int32_t hitsumabushi_renameat(int32_t fd1, char* name1, int32_t fd2, char* name2)
+{
+  fprintf(stderr, "syscall renameat(%d, %s, %d, %s) is not implemented\n", fd1, name1, fd2, name2);
+  return -ENOSYS;
+}
+
+int32_t hitsumabushi_fstatat(int32_t fd, char* name, struct stat* p, int32_t flags)
+{
+  fprintf(stderr, "syscall fstatat(%d, %s, %p, %d) is not implemented\n", fd, name, p, flags);
+  return -ENOSYS;
+}

--- a/1.19_linux/runtime/cgo/hitsumabushi_syscalls_linux.c
+++ b/1.19_linux/runtime/cgo/hitsumabushi_syscalls_linux.c
@@ -9,6 +9,7 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <stdatomic.h>
+#include <sys/stat.h>
 #include <unistd.h> // for usleep
 
 #include "libcgo.h"
@@ -269,6 +270,35 @@ int32_t hitsumabushi_write1(uintptr_t fd, void *p, int32_t n) {
   }
   pthread_mutex_unlock(&m);
   return ret;
+}
+
+int32_t hitsumabushi_lseek(uintptr_t fd, off_t offset, int32_t whence) {
+  fprintf(stderr, "syscall lseek(%lu, %lu, %d) is not implemented\n", fd, offset, whence);
+  return -ENOSYS;
+}
+
+int hitsumabushi_fcntl(int fd, int cmd, int arg)
+{
+  fprintf(stderr, "syscall fcntl(%d, %d, %d) is not implemented\n", fd, cmd, arg);
+  return -ENOSYS;
+}
+
+int hitsumabushi_fstat(int fd, struct stat *stat)
+{
+  fprintf(stderr, "syscall fstat(%d, %p) is not implemented\n", fd, stat);
+  return -ENOSYS;
+}
+
+int hitsumabushi_renameat(int fd1, char* name1, int fd2, char* name2)
+{
+  fprintf(stderr, "syscall renameat(%d, %s, %d, %s) is not implemented\n", fd1, name1, fd2, name2);
+  return -ENOSYS;
+}
+
+int hitsumabushi_fstatat(int fd, char* name, struct stat* p, int flags)
+{
+  fprintf(stderr, "syscall fstatat(%d, %s, %p, %d) is not implemented\n", fd, name, p, flags);
+  return -ENOSYS;
 }
 
 void hitsumabushi_exit(int32_t code) {

--- a/1.19_linux/runtime/cgo/hitsumabushi_syscalls_linux.c
+++ b/1.19_linux/runtime/cgo/hitsumabushi_syscalls_linux.c
@@ -9,9 +9,9 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <stdatomic.h>
-#include <fcntl.h>
-#include <sys/stat.h>
 #include <unistd.h> // for usleep
+#include <stddef.h> // for size_t
+#include <signal.h> // for sigset_t and struct sigaction
 
 #include "libcgo.h"
 #include "libcgo_unix.h"
@@ -106,87 +106,6 @@ int sigismember(const sigset_t *set, int signum) {
   return 0;
 }
 
-static const int kFDOffset = 100;
-
-typedef struct {
-  const void* content;
-  size_t      content_size;
-  size_t      current;
-  int32_t     fd;
-} pseudo_file;
-
-// TODO: Do we need to protect this by mutex?
-static pseudo_file pseudo_files[100];
-
-static pthread_mutex_t* pseudo_file_mutex() {
-  static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
-  return &mutex;
-}
-
-static int32_t open_pseudo_file(const void* content, size_t content_size) {
-  pthread_mutex_lock(pseudo_file_mutex());
-
-  int index = 0;
-  int found = 0;
-  for (int i = 0; i < sizeof(pseudo_files) / sizeof(pseudo_file); i++) {
-    if (pseudo_files[i].fd == 0) {
-      index = i;
-      found = 1;
-      break;
-    }
-  }
-  if (!found) {
-    // Too many pseudo files are opened.
-    pthread_mutex_unlock(pseudo_file_mutex());
-    return -1;
-  }
-  int32_t fd = index + kFDOffset;
-  pseudo_files[index].content = content;
-  pseudo_files[index].content_size = content_size;
-  pseudo_files[index].current = 0;
-  pseudo_files[index].fd = fd;
-
-  pthread_mutex_unlock(pseudo_file_mutex());
-  return fd;
-}
-
-static size_t read_pseudo_file(int32_t fd, void *p, int32_t n) {
-  pthread_mutex_lock(pseudo_file_mutex());
-
-  int32_t index = fd - kFDOffset;
-  pseudo_file *file = &pseudo_files[index];
-  size_t rest = file->content_size - file->current;
-  if (rest < n) {
-    n = rest;
-  }
-  memcpy(p, file->content + file->current, n);
-  pseudo_files[index].current += n;
-
-  pthread_mutex_unlock(pseudo_file_mutex());
-  return n;
-}
-
-static void close_pseudo_file(int32_t fd) {
-  pthread_mutex_lock(pseudo_file_mutex());
-
-  int32_t index = fd - kFDOffset;
-  pseudo_files[index].content = NULL;
-  pseudo_files[index].content_size = 0;
-  pseudo_files[index].current = 0;
-  pseudo_files[index].fd = 0;
-
-  pthread_mutex_unlock(pseudo_file_mutex());
-}
-
-int32_t hitsumabushi_closefd(int32_t fd) {
-  if (fd >= kFDOffset) {
-    close_pseudo_file(fd);
-    return 0;
-  }
-  fprintf(stderr, "syscall close(%d) is not implemented\n", fd);
-  return 0;
-}
-
 uint32_t hitsumabushi_gettid() {
   uint64_t tid64 = (uint64_t)(pthread_self());
   uint32_t tid = (uint32_t)(tid64 >> 32) ^ (uint32_t)(tid64);
@@ -197,25 +116,6 @@ int64_t hitsumabushi_nanotime1() {
   struct timespec tp;
   hitsumabushi_clock_gettime(CLOCK_MONOTONIC, &tp);
   return (int64_t)(tp.tv_sec) * 1000000000ll + (int64_t)tp.tv_nsec;
-}
-
-int32_t hitsumabushi_open(char *name, int32_t mode, int32_t perm) {
-  if (strcmp(name, "/proc/self/auxv") == 0) {
-    static const char auxv[] =
-      "\x06\x00\x00\x00\x00\x00\x00\x00"  // _AT_PAGESZ tag (6)
-      "\x00\x10\x00\x00\x00\x00\x00\x00"  // 4096 bytes per page
-      "\x00\x00\x00\x00\x00\x00\x00\x00"  // Dummy bytes
-      "\x00\x00\x00\x00\x00\x00\x00\x00"; // Dummy bytes
-    return open_pseudo_file(auxv, sizeof(auxv) / sizeof(char));
-  }
-  if (strcmp(name, "/sys/kernel/mm/transparent_hugepage/hpage_pmd_size") == 0) {
-    static const char hpage_pmd_size[] =
-      "\x30\x5c"; // '0', '\n'
-    return open_pseudo_file(hpage_pmd_size, sizeof(hpage_pmd_size) / sizeof(char));
-  }
-  fprintf(stderr, "syscall open(%s, %d, %d) is not implemented\n", name, mode, perm);
-  const static int kENOENT = 0x2;
-  return kENOENT;
 }
 
 int32_t hitsumabushi_osyield() {
@@ -232,15 +132,6 @@ int32_t hitsumabushi_sched_getaffinity(pid_t pid, size_t cpusetsize, void *mask)
     return (numcpu + 7) / 8;
 }
 
-int32_t hitsumabushi_read(int32_t fd, void *p, int32_t n) {
-  if (fd >= kFDOffset) {
-    return read_pseudo_file(fd, p, n);
-  }
-  fprintf(stderr, "syscall read(%d, %p, %d) is not implemented\n", fd, p, n);
-  const static int kEBADF = 0x9;
-  return kEBADF;
-}
-
 void hitsumabushi_usleep(useconds_t usec) {
   usleep(usec);
 }
@@ -250,62 +141,6 @@ void hitsumabushi_walltime1(int64_t* sec, int32_t* nsec) {
   hitsumabushi_clock_gettime(CLOCK_REALTIME, &tp);
   *sec = tp.tv_sec;
   *nsec = tp.tv_nsec;
-}
-
-int32_t hitsumabushi_write1(uintptr_t fd, void *p, int32_t n) {
-  static pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
-  int32_t ret = 0;
-  pthread_mutex_lock(&m);
-  switch (fd) {
-  case 1:
-    ret = fwrite(p, 1, n, stdout);
-    fflush(stdout);
-    break;
-  case 2:
-    ret = fwrite(p, 1, n, stderr);
-    fflush(stderr);
-    break;
-  default:
-    fprintf(stderr, "syscall write(%lu, %p, %d) is not implemented\n", fd, p, n);
-    ret = -EBADF;
-    break;
-  }
-  pthread_mutex_unlock(&m);
-  return ret;
-}
-
-int32_t hitsumabushi_lseek(uintptr_t fd, off_t offset, int32_t whence) {
-  fprintf(stderr, "syscall lseek(%lu, %lu, %d) is not implemented\n", fd, offset, whence);
-  return -ENOSYS;
-}
-
-int hitsumabushi_fcntl(int fd, int cmd, int arg)
-{
-  if (fd == 0 || fd == 1 || fd == 2) {
-    if (cmd == F_GETFL) {
-      return 0;
-    }
-  }
-  fprintf(stderr, "syscall fcntl(%d, %d, %d) is not implemented\n", fd, cmd, arg);
-  return -EBADF;
-}
-
-int hitsumabushi_fstat(int fd, struct stat *stat)
-{
-  fprintf(stderr, "syscall fstat(%d, %p) is not implemented\n", fd, stat);
-  return -ENOSYS;
-}
-
-int hitsumabushi_renameat(int fd1, char* name1, int fd2, char* name2)
-{
-  fprintf(stderr, "syscall renameat(%d, %s, %d, %s) is not implemented\n", fd1, name1, fd2, name2);
-  return -ENOSYS;
-}
-
-int hitsumabushi_fstatat(int fd, char* name, struct stat* p, int flags)
-{
-  fprintf(stderr, "syscall fstatat(%d, %s, %p, %d) is not implemented\n", fd, name, p, flags);
-  return -ENOSYS;
 }
 
 void hitsumabushi_exit(int32_t code) {

--- a/1.19_linux/runtime/cgo/hitsumabushi_syscalls_linux.c
+++ b/1.19_linux/runtime/cgo/hitsumabushi_syscalls_linux.c
@@ -9,6 +9,7 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <stdatomic.h>
+#include <fcntl.h>
 #include <sys/stat.h>
 #include <unistd.h> // for usleep
 
@@ -266,6 +267,7 @@ int32_t hitsumabushi_write1(uintptr_t fd, void *p, int32_t n) {
     break;
   default:
     fprintf(stderr, "syscall write(%lu, %p, %d) is not implemented\n", fd, p, n);
+    ret = -ENOSYS;
     break;
   }
   pthread_mutex_unlock(&m);
@@ -279,6 +281,11 @@ int32_t hitsumabushi_lseek(uintptr_t fd, off_t offset, int32_t whence) {
 
 int hitsumabushi_fcntl(int fd, int cmd, int arg)
 {
+  if (fd == 0 || fd == 1 || fd == 2) {
+    if (cmd == F_GETFL) {
+      return 0;
+    }
+  }
   fprintf(stderr, "syscall fcntl(%d, %d, %d) is not implemented\n", fd, cmd, arg);
   return -ENOSYS;
 }

--- a/1.19_linux/runtime/cgo/hitsumabushi_syscalls_linux.c
+++ b/1.19_linux/runtime/cgo/hitsumabushi_syscalls_linux.c
@@ -267,7 +267,7 @@ int32_t hitsumabushi_write1(uintptr_t fd, void *p, int32_t n) {
     break;
   default:
     fprintf(stderr, "syscall write(%lu, %p, %d) is not implemented\n", fd, p, n);
-    ret = -ENOSYS;
+    ret = -EBADF;
     break;
   }
   pthread_mutex_unlock(&m);
@@ -287,7 +287,7 @@ int hitsumabushi_fcntl(int fd, int cmd, int arg)
     }
   }
   fprintf(stderr, "syscall fcntl(%d, %d, %d) is not implemented\n", fd, cmd, arg);
-  return -ENOSYS;
+  return -EBADF;
 }
 
 int hitsumabushi_fstat(int fd, struct stat *stat)

--- a/1.19_linux/runtime/os_linux.go.patch
+++ b/1.19_linux/runtime/os_linux.go.patch
@@ -292,3 +292,38 @@ var hitsumabushi_walltime1 byte
 //go:linkname hitsumabushi_write1 hitsumabushi_write1
 //go:cgo_import_static hitsumabushi_write1
 var hitsumabushi_write1 byte
+
+//go:nosplit
+//go:cgo_unsafe_args
+func fcntl1(fd, cmd, arg int) int32 {
+	return libcCall(unsafe.Pointer(abi.FuncPCABI0(fcntl_trampoline)), unsafe.Pointer(&fd))
+}
+func fcntl_trampoline()
+
+//go:nosplit
+//go:cgo_unsafe_args
+func fstat1(fd int, stat unsafe.Pointer) int32 {
+	return libcCall(unsafe.Pointer(abi.FuncPCABI0(fstat_trampoline)), unsafe.Pointer(&fd))
+}
+func fstat_trampoline(fd int, stat unsafe.Pointer) int32
+
+//go:nosplit
+//go:cgo_unsafe_args
+func lseek1(fd int, offset int64, whence int) int32 {
+	return libcCall(unsafe.Pointer(abi.FuncPCABI0(lseek_trampoline)), unsafe.Pointer(&fd))
+}
+func lseek_trampoline()
+
+//go:nosplit
+//go:cgo_unsafe_args
+func renameat(fd1 int, name1 unsafe.Pointer, fd2 int, name2 unsafe.Pointer) int32 {
+	return libcCall(unsafe.Pointer(abi.FuncPCABI0(renameat_trampoline)), unsafe.Pointer(&fd1))
+}
+func renameat_trampoline()
+
+//go:nosplit
+//go:cgo_unsafe_args
+func fstatat(fd uintptr, name unsafe.Pointer, p unsafe.Pointer, n int32) int32 {
+	return libcCall(unsafe.Pointer(abi.FuncPCABI0(fstatat_trampoline)), unsafe.Pointer(&fd))
+}
+func fstatat_trampoline()

--- a/1.19_linux/runtime/sys_linux_amd64.s.patch
+++ b/1.19_linux/runtime/sys_linux_amd64.s.patch
@@ -417,3 +417,64 @@ TEXT runtime·walltime1_trampoline(SB),NOSPLIT,$0
 	MOVQ	AX, 16(BX)	// return value
 	POPQ	BP
 	RET
+
+TEXT runtime·fcntl_trampoline(SB),NOSPLIT,$0
+	PUSHQ	BP
+	MOVQ	SP, BP
+	MOVQ	8(DI), SI		// arg 2 cmd
+	MOVQ	16(DI), DX		// arg 3 arg
+	MOVQ	0(DI), DI		// arg 1 fd
+	XORL	AX, AX			// vararg: say "no float args"
+	CALL	hitsumabushi_fcntl(SB)
+	POPQ	BP
+	RET
+
+TEXT runtime·fstat_trampoline(SB),NOSPLIT,$0
+	PUSHQ	BP
+	MOVQ	SP, BP
+	MOVQ	DI, BX
+	MOVQ	8(DI), SI		// arg 2 stat
+	MOVQ	0(DI), DI		// arg 1 fd
+	CALL	hitsumabushi_fstat(SB)
+	MOVQ	AX, 16(BX)	// return value
+	POPQ	BP
+	RET
+
+TEXT runtime·lseek_trampoline(SB),NOSPLIT,$0
+	PUSHQ	BP
+	MOVQ	SP, BP
+	MOVQ	DI, BX
+	MOVQ	8(DI), SI		// arg 2 offset
+	MOVQ	16(DI), DX		// arg 3 whence
+	MOVQ	0(DI), DI		// arg 1 fd
+	XORL	AX, AX			// vararg: say "no float args"
+	CALL	hitsumabushi_lseek(SB)
+	MOVQ	AX, 24(BX)	// return value
+	POPQ	BP
+	RET
+
+TEXT runtime·renameat_trampoline(SB),NOSPLIT,$0
+	PUSHQ	BP
+	MOVQ	SP, BP
+	MOVQ	DI, BX
+	MOVQ	0(BX), DI		// arg 1
+	MOVQ	8(BX), SI		// arg 2
+	MOVQ	16(BX), DX		// arg 3
+	MOVQ	24(BX), CX		// arg 4
+	CALL	hitsumabushi_renameat(SB)
+	MOVL	AX, 32(BX)
+	POPQ	BP
+	RET
+
+TEXT runtime·fstatat_trampoline(SB),NOSPLIT,$0
+	PUSHQ	BP
+	MOVQ	SP, BP
+	MOVQ	DI, BX
+	MOVQ	0(BX), DI		// arg 1
+	MOVQ	8(BX), SI		// arg 2
+	MOVQ	16(BX), DX		// arg 3
+	MOVQ	24(BX), CX		// arg 4
+	CALL	hitsumabushi_fstatat(SB)
+	MOVL	AX, 32(BX)
+	POPQ	BP
+	RET

--- a/1.19_linux/runtime/sys_linux_arm64.s.patch
+++ b/1.19_linux/runtime/sys_linux_arm64.s.patch
@@ -503,3 +503,49 @@ TEXT runtime·sysMapOS_trampoline(SB),NOSPLIT,$0
 	MOVD	0(R0), R0
 	BL	hitsumabushi_sysMapOS(SB)
 	RET
+
+TEXT runtime·fcntl_trampoline(SB),NOSPLIT,$0
+	MOVD	R0, R19		// R19 is callee-save
+	MOVW	8(R0), R1
+	MOVW	16(R0), R2
+	MOVW	0(R0), R0
+	BL	hitsumabushi_fcntl(SB)
+	MOVW	R0, 24(R19)	// return value
+	RET
+
+TEXT runtime·fstat_trampoline(SB),NOSPLIT,$0
+	MOVD	R0, R19		// R19 is callee-save
+	MOVD	8(R0), R1
+	MOVW	0(R0), R0
+	BL	hitsumabushi_fstat(SB)
+	MOVW	R0, 16(R19)	// return value
+	RET
+
+TEXT runtime·lseek_trampoline(SB),NOSPLIT,$0
+	MOVD	R0, R19		// R19 is callee-save
+	MOVD	8(R0), R1
+	MOVW	16(R0), R2
+	MOVW	0(R0), R0
+	BL	hitsumabushi_lseek(SB)
+	MOVW	R0, 24(R19)	// return value
+	RET
+
+TEXT runtime·renameat_trampoline(SB),NOSPLIT,$0
+	MOVD	R0, R19		// R19 is callee-save
+	MOVD	8(R0), R1
+	MOVD	16(R0), R2
+	MOVW	24(R0), R3
+	MOVD	0(R0), R0
+	BL	hitsumabushi_renameat(SB)
+	MOVW	R0, 32(R19)	// return value
+	RET
+
+TEXT runtime·fstatat_trampoline(SB),NOSPLIT,$0
+	MOVD	R0, R19		// R19 is callee-save
+	MOVD	8(R0), R1
+	MOVD	16(R0), R2
+	MOVW	24(R0), R3
+	MOVD	0(R0), R0
+	BL	hitsumabushi_fstatat(SB)
+	MOVW	R0, 32(R19)	// return value
+	RET

--- a/1.19_linux/syscall/syscall_linux.go.patch
+++ b/1.19_linux/syscall/syscall_linux.go.patch
@@ -43,6 +43,14 @@ func Syscall(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err Errno) {
 		r = lseek1(a1, int64(a2), int32(a3))
 	case SYS_CLOSE:
 		r = runtime_closefd(int32(a1))
+	case SYS_MKDIRAT:
+		println("syscall mkdirat() is not implemented")
+		// Default to permission denied. TODO: implement this
+		return 0, 0, EPERM
+	case SYS_GETDENTS64:
+		println("syscall getdents64() is not implemented")
+		// Default to empty directory. TODO: implement this
+		return 0, 0, 0
 	default:
 		println("unimplemented syscall at runtime.Syscall", trap)
 		panic("syscall.Syscall")
@@ -55,6 +63,8 @@ func Syscall(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err Errno) {
 	return uintptr(r), 0, 0
 }
 
+//go:linkname open runtime.open
+func open(name *byte, mode, perm int32) int32
 //go:linkname write1 runtime.write1
 func write1(fd uintptr, p unsafe.Pointer, n int32) int32
 //go:linkname fcntl1 runtime.fcntl1
@@ -96,4 +106,20 @@ func Syscall6(trap, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2 uintptr, err Errno) 
 		return 0, 0, Errno(-r)
 	}
 	return uintptr(r), 0, 0
+}
+//--from
+func Open(path string, mode int, perm uint32) (fd int, err error) {
+	return openat(_AT_FDCWD, path, mode|O_LARGEFILE, perm)
+}
+//--to
+func Open(path string, mode int, perm uint32) (fd int, err error) {
+	p0, err := BytePtrFromString(path)
+	if err != nil {
+		return -1, errnoErr(EINVAL)
+	}
+	fd = int(open(p0, int32(mode|O_LARGEFILE), int32(perm)))
+	if fd < 0 {
+		return -1, errnoErr(ENOENT)
+	}
+	return
 }

--- a/1.19_linux/syscall/syscall_linux.go.patch
+++ b/1.19_linux/syscall/syscall_linux.go.patch
@@ -29,37 +29,48 @@ func Syscall(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err Errno) {
 }
 //--to
 func Syscall(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err Errno) {
+	var r int32
 	switch trap {
 	case SYS_FCNTL:
-		if a1 == uintptr(Stdin) || a1 == uintptr(Stdout) || a1 == uintptr(Stderr) {
-			if a2 == F_GETFL {
-				return 0, 0, 0
-			}
-		}
-		println("unexpected fcntl:", a1, a2, a3)
+		r = fcntl1(a1, a2, a3)
+	case SYS_FSTAT:
+		r = fstat1(a1, unsafe.Pointer(a2))
 	case SYS_READ:
-		if a1 == uintptr(Stdin) {
-			if a3 == 0 {
-				return 0, 0, 0
-			}
-			// TODO: Implement this
-		}
+		r = runtime_read(uintptr(a1), unsafe.Pointer(a2), int32(a3))
 	case SYS_WRITE:
-		if a1 == uintptr(Stdout) || a1 == uintptr(Stderr) {
-			if a3 == 0 {
-				return 0, 0, 0
-			}
-			r := write1(a1, unsafe.Pointer(a2), int32(a3))
-			return uintptr(r), 0, 0
-		}
+		r = write1(a1, unsafe.Pointer(a2), int32(a3))
+	case SYS_LSEEK:
+		r = lseek1(a1, int64(a2), int32(a3))
+	case SYS_CLOSE:
+		r = runtime_closefd(int32(a1))
+	default:
+		println("unimplemented syscall at runtime.Syscall", trap)
+		panic("syscall.Syscall")
+		return 0, 0, ENOSYS
 	}
-	println("not implemented syscall at runtime.Syscall", trap)
-	panic("syscall.Syscall")
-	return 0, 0, ENOSYS
+
+	if r < 0 {
+		return 0, 0, Errno(-r)
+	}
+	return uintptr(r), 0, 0
 }
 
 //go:linkname write1 runtime.write1
 func write1(fd uintptr, p unsafe.Pointer, n int32) int32
+//go:linkname fcntl1 runtime.fcntl1
+func fcntl1(fd uintptr, a uintptr, b uintptr) int32
+//go:linkname fstat1 runtime.fstat1
+func fstat1(fd uintptr, p unsafe.Pointer) int32
+//go:linkname lseek1 runtime.lseek1
+func lseek1(fd uintptr, offset int64, whence int32) int32
+//go:linkname runtime_read runtime.read
+func runtime_read(fd uintptr, p unsafe.Pointer, n int32) int32
+//go:linkname runtime_closefd runtime.closefd
+func runtime_closefd(fd int32) int32
+//go:linkname runtime_fstatat runtime.fstatat
+func runtime_fstatat(fd uintptr, name unsafe.Pointer, p unsafe.Pointer, n int32) int32
+//go:linkname runtime_renameat runtime.renameat
+func runtime_renameat(fd1 uintptr, name1 unsafe.Pointer, fd2 uintptr, name2 unsafe.Pointer) int32
 //--from
 func Syscall6(trap, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2 uintptr, err Errno) {
 	runtime_entersyscall()
@@ -69,11 +80,20 @@ func Syscall6(trap, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2 uintptr, err Errno) 
 }
 //--to
 func Syscall6(trap, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2 uintptr, err Errno) {
+	var r int32
 	switch trap {
 	case SYS_FSTATAT, SYS_NEWFSTATAT:
-		return 0, 0, ENOENT
+		r = runtime_fstatat(uintptr(a1), unsafe.Pointer(a2), unsafe.Pointer(a3), int32(a4))
+	case SYS_RENAMEAT:
+		r = runtime_renameat(uintptr(a1), unsafe.Pointer(a2), uintptr(a3), unsafe.Pointer(a4))
+	default:
+		println("unimplemented syscall at runtime.Syscall6", trap)
+		panic("syscall.Syscall6")
+		return 0, 0, ENOSYS
 	}
-	println("not implemented syscall at runtime.Syscall6", trap)
-	panic("syscall.Syscall6")
-	return 0, 0, ENOSYS
+
+	if r < 0 {
+		return 0, 0, Errno(-r)
+	}
+	return uintptr(r), 0, 0
 }

--- a/overlay.go
+++ b/overlay.go
@@ -626,6 +626,26 @@ func FutexFilePath(os string) (string, error) {
 	return replacementFilePath("FutexFilePath", "runtime/cgo", os, "hitsumabushi_futex_linux.c")
 }
 
+// FilesystemFilePath returns a C file's path for the filesystem functions.
+// This file works only when linux is specified as the GOOS option.
+//
+// The file includes these functions:
+//
+//   - int32_t hitsumabushi_closefd(int32_t fd)
+//   - int32_t hitsumabushi_open(char *name, int32_t mode, int32_t perm)
+//   - int32_t hitsumabushi_read(int32_t fd, void *p, int32_t n)
+//   - int32_t hitsumabushi_write1(uintptr_t fd, void *p, int32_t n)
+//   - int32_t hitsumabushi_lseek(uintptr_t fd, off_t offset, int32_t whence)
+//   - int32_t hitsumabushi_fcntl(int32_t fd, int32_t cmd, int32_t arg)
+//   - int32_t hitsumabushi_fstat(int32_t fd, struct stat *stat)
+//   - int32_t hitsumabushi_renameat(int32_t fd1, char* name1, int32_t fd2, char* name2)
+//   - int32_t hitsumabushi_fstatat(int32_t fd, char* name, struct stat* p, int32_t flags)
+//
+// The default implementation only handles stdout, stderr, and some pseudo-files.
+func FilesystemFilePath(os string) (string, error) {
+	return replacementFilePath("FilesystemFilePath", "runtime/cgo", os, "hitsumabushi_filesystem_linux.c")
+}
+
 // MemoryFilePath returns a C file's path for the memory functions.
 // This file works only when linux is specified as the GOOS option.
 //


### PR DESCRIPTION
This is the filesystem-specific part of #13:
 - implement more syscalls (`fcntl`, `fstat`…)
 - move everything filesystem-related to a separate C file
 - add a `FilesystemFilePath()` function in `overlay.go` for the user to add their own implementation
 - move some logic (`stdin`/`stderr`) from the Go side to C