### PR TITLE
Disable multiple C stub functions

### DIFF
--- a/1.19_linux/net/cgo_linux.go.patch
+++ b/1.19_linux/net/cgo_linux.go.patch
@@ -1,0 +1,4 @@
+//--from
+//go:build !android && cgo && !netgo
+//--to
+//go:build ignore

--- a/1.19_linux/net/cgo_resnew.go.patch
+++ b/1.19_linux/net/cgo_resnew.go.patch
@@ -1,0 +1,4 @@
+//--from
+//go:build cgo && !netgo && (darwin || (linux && !android) || netbsd || solaris)
+//--to
+//go:build ignore

--- a/1.19_linux/net/cgo_unix.go.patch
+++ b/1.19_linux/net/cgo_unix.go.patch
@@ -1,0 +1,4 @@
+//--from
+//go:build cgo && !netgo && unix
+//--to
+//go:build ignore

--- a/1.19_linux/net/lookup_fake.go.patch
+++ b/1.19_linux/net/lookup_fake.go.patch
@@ -1,0 +1,4 @@
+//--from
+//go:build js && wasm
+//--to
+// We want to actually build this file (because we disable lookup_unix.go)

--- a/1.19_linux/net/lookup_unix.go.patch
+++ b/1.19_linux/net/lookup_unix.go.patch
@@ -1,0 +1,4 @@
+//--from
+//go:build unix
+//--to
+//go:build ignore

--- a/1.19_linux/runtime/cgo/gcc_linux_amd64.c.patch
+++ b/1.19_linux/runtime/cgo/gcc_linux_amd64.c.patch
@@ -1,0 +1,48 @@
+//--from
+#include <signal.h>
+//--to
+
+//--from
+void
+_cgo_sys_thread_start(ThreadStart *ts)
+{
+	pthread_attr_t attr;
+	sigset_t ign, oset;
+	pthread_t p;
+	size_t size;
+	int err;
+
+	sigfillset(&ign);
+	pthread_sigmask(SIG_SETMASK, &ign, &oset);
+
+	pthread_attr_init(&attr);
+	pthread_attr_getstacksize(&attr, &size);
+	// Leave stacklo=0 and set stackhi=size; mstart will do the rest.
+	ts->g->stackhi = size;
+	err = _cgo_try_pthread_create(&p, &attr, threadentry, ts);
+
+	pthread_sigmask(SIG_SETMASK, &oset, nil);
+
+	if (err != 0) {
+		fatalf("pthread_create failed: %s", strerror(err));
+	}
+}
+//--to
+void
+_cgo_sys_thread_start(ThreadStart *ts)
+{
+	pthread_attr_t attr;
+	pthread_t p;
+	size_t size;
+	int err;
+
+	pthread_attr_init(&attr);
+	pthread_attr_getstacksize(&attr, &size);
+	// Leave stacklo=0 and set stackhi=size; mstart will do the rest.
+	ts->g->stackhi = size;
+	err = _cgo_try_pthread_create(&p, &attr, threadentry, ts);
+
+	if (err != 0) {
+		fatalf("pthread_create failed: %s", strerror(err));
+	}
+}

--- a/1.19_linux/runtime/cgo/gcc_linux_amd64.c.patch
+++ b/1.19_linux/runtime/cgo/gcc_linux_amd64.c.patch
@@ -1,7 +1,6 @@
 //--from
 #include <signal.h>
 //--to
-
 //--from
 void
 _cgo_sys_thread_start(ThreadStart *ts)

--- a/1.19_linux/runtime/cgo/gcc_linux_arm64.c.patch
+++ b/1.19_linux/runtime/cgo/gcc_linux_arm64.c.patch
@@ -1,7 +1,6 @@
 //--from
 #include <signal.h>
 //--to
-
 //--from
 void
 _cgo_sys_thread_start(ThreadStart *ts)

--- a/1.19_linux/runtime/cgo/gcc_linux_arm64.c.patch
+++ b/1.19_linux/runtime/cgo/gcc_linux_arm64.c.patch
@@ -1,4 +1,8 @@
 //--from
+#include <signal.h>
+//--to
+
+//--from
 void
 _cgo_sys_thread_start(ThreadStart *ts)
 {
@@ -28,13 +32,9 @@ void
 _cgo_sys_thread_start(ThreadStart *ts)
 {
 	pthread_attr_t attr;
-	sigset_t ign, oset;
 	pthread_t p;
 	size_t size;
 	int err;
-
-	sigfillset(&ign);
-	pthread_sigmask(SIG_SETMASK, &ign, &oset);
 
 	pthread_attr_init(&attr);
 	pthread_attr_setstacksize(&attr, 16 * 4096); // Hack for some special environments
@@ -42,8 +42,6 @@ _cgo_sys_thread_start(ThreadStart *ts)
 	// Leave stacklo=0 and set stackhi=size; mstart will do the rest.
 	ts->g->stackhi = size;
 	err = _cgo_try_pthread_create(&p, &attr, threadentry, ts);
-
-	pthread_sigmask(SIG_SETMASK, &oset, nil);
 
 	if (err != 0) {
 		fatalf("pthread_create failed: %s", strerror(err));

--- a/1.19_linux/runtime/cgo/gcc_setenv.c.patch
+++ b/1.19_linux/runtime/cgo/gcc_setenv.c.patch
@@ -1,0 +1,8 @@
+//--from
+	setenv(arg[0], arg[1], 1);
+//--to
+	// do nothing
+//--from
+	unsetenv(arg[0]);
+//--to
+	// do nothing

--- a/1.19_linux/runtime/cgo/gcc_sigaction.c
+++ b/1.19_linux/runtime/cgo/gcc_sigaction.c
@@ -1,0 +1,3 @@
+#include <stdint.h>
+
+int32_t x_cgo_sigaction() { return 0; }

--- a/1.19_linux/runtime/cgo/hitsumabushi_syscalls_linux.c
+++ b/1.19_linux/runtime/cgo/hitsumabushi_syscalls_linux.c
@@ -3,108 +3,18 @@
 
 // This file defines C functions and system calls for Cgo.
 
-#include <pthread.h>
-#include <errno.h>
-#include <string.h>
-#include <signal.h>
-#include <stdlib.h>
-#include <stdatomic.h>
+#include <pthread.h> // for pthread_self
+#include <stdint.h> // for uint32_t etc.
+#include <stdlib.h> // for exit()
 #include <unistd.h> // for usleep
 #include <stddef.h> // for size_t
-#include <signal.h> // for sigset_t and struct sigaction
+#include <time.h> // for struct timespec
 
 #include "libcgo.h"
 #include "libcgo_unix.h"
 
-typedef unsigned int gid_t;
-
 extern int hitsumabushi_clock_gettime(clockid_t clk_id, struct timespec *tp);
 extern int32_t hitsumabushi_getproccount();
-
-void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
-  abort();
-  return NULL;
-}
-
-int munmap(void *addr, size_t length) {
-  abort();
-  return 0;
-}
-
-int pthread_sigmask(int how, const sigset_t *set, sigset_t *oldset) {
-  // Do nothing.
-  return 0;
-}
-
-int setegid(gid_t gid) {
-  // Do nothing.
-  return 0;
-}
-
-int seteuid(uid_t gid) {
-  // Do nothing.
-  return 0;
-}
-
-int setgid(gid_t gid) {
-  // Do nothing.
-  return 0;
-}
-
-int setgroups(size_t size, const gid_t *list) {
-  // Do nothing.
-  return 0;
-}
-
-int setregid(gid_t rgid, gid_t egid) {
-  // Do nothing.
-  return 0;
-}
-
-int setreuid(uid_t ruid, uid_t euid) {
-  // Do nothing.
-  return 0;
-}
-
-int setresgid(gid_t rgid, gid_t egid, gid_t sgid) {
-  // Do nothing.
-  return 0;
-}
-
-int setresuid(uid_t ruid, uid_t euid, uid_t suid) {
-  // Do nothing.
-  return 0;
-}
-
-int setuid(uid_t gid) {
-  // Do nothing.
-  return 0;
-}
-
-int sigaction(int signum, const struct sigaction *act, struct sigaction *oldact) {
-  // Do nothing.
-  return 0;
-}
-
-int sigaddset(sigset_t *set, int signum) {
-  // Do nothing.
-  return 0;
-}
-
-int sigemptyset(sigset_t *set) {
-  // Do nothing.
-  return 0;
-}
-
-int sigfillset(sigset_t *set) {
-  // Do nothing.
-  return 0;
-}
-
-int sigismember(const sigset_t *set, int signum) {
-  // Do nothing.
-  return 0;
-}
 
 uint32_t hitsumabushi_gettid() {
   uint64_t tid64 = (uint64_t)(pthread_self());

--- a/1.19_linux/runtime/cgo/linux.go.patch
+++ b/1.19_linux/runtime/cgo/linux.go.patch
@@ -1,0 +1,4 @@
+//--from
+//go:build linux
+//--to
+//go:build ignore

--- a/1.19_linux/runtime/cgo/linux_syscall.c.patch
+++ b/1.19_linux/runtime/cgo/linux_syscall.c.patch
@@ -1,0 +1,4 @@
+//--from
+// +build linux
+//--to
+// +build ignore


### PR DESCRIPTION
One of the root problems is that the PlayStation does not have `<signal.h>`, so we need to disable this header in `gcc_linux_amd64.c`. But then it also makes sense to disable it in `gcc_linux_arm64.c` since it’ll just call stubs anyway.

Other parts of the Go runtime use networking-related headers such as `<netdb.h>` or `<netinet/in.h>` to retrieve constants, so these need to be disabled for the PlayStation compiler, too.

We can actually do the same for calls to *e.g.* `setenv`, or `setgid`, etc. In the end, it is possible to get rid of all C stubs in `hitsumabushi_syscalls_linux.c`.

This was successfully tested with the following setups:
 - Nintendo Switch (with native `clang.exe` from NDK 15.2)
 - PS4 (with native `clang.exe` from SDK 10.000)
 - PS5 (with native `clang.exe` from SDK 5.000)